### PR TITLE
Include full semver version in version.properties

### DIFF
--- a/src/main/kotlin/net/thauvin/erik/gradle/semver/SemverConfig.kt
+++ b/src/main/kotlin/net/thauvin/erik/gradle/semver/SemverConfig.kt
@@ -35,6 +35,7 @@ open class SemverConfig {
     companion object {
         const val DEFAULT_KEYS_PREFIX = "version."
         const val DEFAULT_PROPERTIES = "${DEFAULT_KEYS_PREFIX}properties"
+        const val DEFAULT_SEMVER_KEY = "semver"
         const val DEFAULT_MAJOR_KEY = "major"
         const val DEFAULT_MINOR_KEY = "minor"
         const val DEFAULT_PATCH_KEY = "patch"
@@ -46,6 +47,8 @@ open class SemverConfig {
     }
 
     var properties = DEFAULT_PROPERTIES
+    var semverKey = DEFAULT_SEMVER_KEY
+        get() = "$keysPrefix$field"
     var majorKey = DEFAULT_MAJOR_KEY
         get() = "$keysPrefix$field"
     var minorKey = DEFAULT_MINOR_KEY

--- a/src/main/kotlin/net/thauvin/erik/gradle/semver/Utils.kt
+++ b/src/main/kotlin/net/thauvin/erik/gradle/semver/Utils.kt
@@ -34,6 +34,7 @@ object Utils {
                 }
             }
 
+            put(config.semverKey, version.semver)
             put(config.majorKey, version.major)
             put(config.minorKey, version.minor)
             put(config.patchKey, version.patch)


### PR DESCRIPTION
So it could be interpreted by other (build) scripting for example.